### PR TITLE
Switch rendering to Markdown

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,9 @@ at https://www.dokuwiki.org/
 For Installation Instructions see
 https://www.dokuwiki.org/install
 
+This version renders pages in Markdown. See `docs/MIGRATION_TO_MARKDOWN.md`
+for converting existing pages.
+
 DokuWiki - 2004-2024 (c) Andreas Gohr <andi@splitbrain.org>
                          and the DokuWiki Community
 See COPYING and file headers for license info

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,10 @@ at https://www.dokuwiki.org/
 For Installation Instructions see
 https://www.dokuwiki.org/install
 
+This version renders pages in Markdown. See `docs/MIGRATION_TO_MARKDOWN.md`
+for converting existing pages.
+
 DokuWiki - 2004-2024 (c) Andreas Gohr <andi@splitbrain.org>
                          and the DokuWiki Community
 See COPYING and file headers for license info
+

--- a/bin/convert_to_markdown.sh
+++ b/bin/convert_to_markdown.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Convert all DokuWiki pages to Markdown using pandoc
+
+set -e
+find data/pages -name '*.txt' -type f | while read -r f; do
+    cp "$f" "$f.bak"
+    pandoc -f dokuwiki -t markdown "$f.bak" -o "$f"
+done
+

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "splitbrain/slika": "^1.0",
         "kissifrot/php-ixr": "^1.8",
         "splitbrain/php-jsstrip": "^1.0",
-        "php81_bc/strftime": "dev-fallback-intl"
+        "php81_bc/strftime": "dev-fallback-intl",
+        "league/commonmark": "^2.4"
     },
     "config": {
         "platform": {

--- a/docs/MIGRATION_TO_MARKDOWN.md
+++ b/docs/MIGRATION_TO_MARKDOWN.md
@@ -1,0 +1,19 @@
+# Migrating existing pages to Markdown
+
+To convert existing DokuWiki pages (`*.txt`) to Markdown you need
+[Pandoc](https://pandoc.org/) installed. The script below processes
+all pages below `data/pages` and keeps a backup of each file:
+
+```sh
+#!/bin/sh
+set -e
+find data/pages -name '*.txt' -type f | while read -r f; do
+    cp "$f" "$f.bak"
+    pandoc -f dokuwiki -t markdown "$f.bak" -o "$f"
+done
+```
+
+Run it from the root of your installation. Once you verified the
+result you can remove the `.bak` files.
+
+

--- a/inc/parser/markdown.php
+++ b/inc/parser/markdown.php
@@ -1,0 +1,38 @@
+<?php
+
+use League\CommonMark\CommonMarkConverter;
+
+/**
+ * Renderer that treats the source as Markdown using league/commonmark
+ */
+class Doku_Renderer_markdown extends Doku_Renderer
+{
+    /** @var string collected markdown source */
+    protected $md = '';
+
+    /** @inheritdoc */
+    public function getFormat()
+    {
+        return 'xhtml';
+    }
+
+    /** @inheritdoc */
+    public function document_start()
+    {
+        $this->md = '';
+    }
+
+    /** @inheritdoc */
+    public function cdata($text)
+    {
+        $this->md .= $text;
+    }
+
+    /** @inheritdoc */
+    public function document_end()
+    {
+        $converter = new CommonMarkConverter();
+        $html = $converter->convert($this->md)->getContent();
+        $this->doc .= '<div class="markdown-body">' . $html . '</div>';
+    }
+}

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -1,35 +1,71 @@
 <?php
 
+use dokuwiki\Debug\PropertyDeprecationHelper;
+
 /**
  * Define various types of modes used by the parser - they are used to
  * populate the list of modes another mode accepts
- *
- * @todo these should be moved to class constants or a generator method
  */
 global $PARSER_MODES;
 $PARSER_MODES = [
-    // containers are complex modes that can contain many other modes
-    // hr breaks the principle but they shouldn't be used in tables / lists
-    // so they are put here
-    'container' => ['listblock', 'table', 'quote', 'hr'],
-    // some mode are allowed inside the base mode only
-    'baseonly' => ['header'],
-    // modes for styling text -- footnote behaves similar to styling
-    'formatting' => [
-        'strong', 'emphasis', 'underline', 'monospace', 'subscript', 'superscript', 'deleted', 'footnote'
-    ],
-    // modes where the token is simply replaced - they can not contain any
-    // other modes
-    'substition' => [
-        'acronym', 'smiley', 'wordblock', 'entity', 'camelcaselink', 'internallink', 'media', 'externallink',
-        'linebreak', 'emaillink', 'windowssharelink', 'filelink', 'notoc', 'nocache', 'multiplyentity', 'quotes', 'rss'
-    ],
-    // modes which have a start and end token but inside which
-    // no other modes should be applied
-    'protected' => ['preformatted', 'code', 'file'],
-    // inside this mode no wiki markup should be applied but lineendings
-    // and whitespace isn't preserved
-    'disabled' => ['unformatted'],
-    // used to mark paragraph boundaries
-    'paragraphs' => ['eol'],
+    'container' => [],
+    'baseonly' => [],
+    'formatting' => [],
+    'substition' => [],
+    'protected' => [],
+    'disabled' => [],
+    'paragraphs' => []
 ];
+
+/**
+ * Class Doku_Parser
+ *
+ * @deprecated 2018-05-04
+ */
+class Doku_Parser extends \dokuwiki\Parsing\Parser {
+    use PropertyDeprecationHelper {
+        __set as protected deprecationHelperMagicSet;
+        __get as protected deprecationHelperMagicGet;
+    }
+
+    /** @inheritdoc */
+    public function __construct(Doku_Handler $handler = null) {
+        dbg_deprecated(\dokuwiki\Parsing\Parser::class);
+        $this->deprecatePublicProperty('modes', __CLASS__);
+        $this->deprecatePublicProperty('connected', __CLASS__);
+
+        if ($handler === null) {
+            $handler = new Doku_Handler();
+        }
+
+        parent::__construct($handler);
+    }
+
+    public function __set($name, $value)
+    {
+        if ($name === 'Handler') {
+            $this->handler = $value;
+            return;
+        }
+
+        if ($name === 'Lexer') {
+            $this->lexer = $value;
+            return;
+        }
+
+        $this->deprecationHelperMagicSet($name, $value);
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'Handler') {
+            return $this->handler;
+        }
+
+        if ($name === 'Lexer') {
+            return $this->lexer;
+        }
+
+        return $this->deprecationHelperMagicGet($name);
+    }
+}

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -715,6 +715,10 @@ function p_get_renderer($mode)
     /** @var PluginController $plugin_controller */
     global $conf, $plugin_controller;
 
+    if ($mode === 'xhtml' && class_exists('Doku_Renderer_markdown')) {
+        return new Doku_Renderer_markdown();
+    }
+
     $rname = empty($conf['renderer_' . $mode]) ? $mode : $conf['renderer_' . $mode];
     $rclass = "Doku_Renderer_$rname";
 

--- a/index.php
+++ b/index.php
@@ -10,6 +10,8 @@
  * Usage example:
  *
  *   php -S localhost:8000 index.php
+
+ * All wiki pages are expected to contain Markdown markup.
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Andreas Gohr <andi@splitbrain.org>

--- a/lib/tpl/dokuwiki/css/_markdown.css
+++ b/lib/tpl/dokuwiki/css/_markdown.css
@@ -1,0 +1,14 @@
+/* Basic Markdown styling */
+.markdown-body {
+    line-height: 1.5;
+    font-size: 1em;
+}
+.markdown-body pre {
+    background: #f7f7f7;
+    padding: 0.5em;
+    overflow: auto;
+}
+.markdown-body code {
+    background: #f2f2f2;
+    padding: 2px 4px;
+}

--- a/lib/tpl/dokuwiki/style.ini
+++ b/lib/tpl/dokuwiki/style.ini
@@ -37,6 +37,7 @@ css/design.less           = screen
 css/usertools.less        = screen
 css/pagetools.less        = screen
 css/content.less          = screen
+css/_markdown.css         = screen
 
 css/mobile.less           = all
 css/print.css             = print


### PR DESCRIPTION
## Summary
- add `league/commonmark` as a Composer dependency
- disable built-in syntax modes
- create a minimal Markdown renderer
- use Markdown renderer for XHTML output
- add stylesheet support for Markdown
- document migration instructions and script
- restore parser class and improve migration docs
- note Markdown usage in README

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401a8b972c8332abfcf64b25c0138b